### PR TITLE
make Ruby API examples more idiomatic

### DIFF
--- a/INTEGRATION_API/Ack/post_acknowledge.rb
+++ b/INTEGRATION_API/Ack/post_acknowledge.rb
@@ -1,22 +1,28 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_key='CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_KEY = 'CHANGE_THIS'
 
-endpoint="https://events.pagerduty.com/generic/2010-04-15/create_event.json"
-token_string="Token token=#{api_token}"
+ENDPOINT = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       service_key: service_key,
-       incident_key: "srv01/HTTP",
-       event_type: "acknowledge",
-       description: "Andrew now working on the problem.",
-       details: "work started: 2010-06-10 05:43" 
-       }
+  service_key: SERVICE_KEY,
+  incident_key: 'srv01/HTTP',
+  event_type: 'acknowledge',
+  description: 'Andrew now working on the problem.',
+  details: 'work started: 2010-06-10 05:43'
+}
 
-response= HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/INTEGRATION_API/Resolve/post_resolve.rb
+++ b/INTEGRATION_API/Resolve/post_resolve.rb
@@ -1,22 +1,28 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_key='CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_KEY = 'CHANGE_THIS'
 
-endpoint="https://events.pagerduty.com/generic/2010-04-15/create_event.json"
-token_string="Token token=#{api_token}"
+ENDPOINT = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       service_key: service_key,
-       incident_key: "srv01/HTTP",
-       event_type: "resolve",
-       description: "Andrew fixed the problem.",
-       details: "2010-06-10 06:00" 
-       }
+  service_key: SERVICE_KEY,
+  incident_key: 'srv01/HTTP',
+  event_type: 'resolve',
+  description: 'Andrew fixed the problem.',
+  details: '2010-06-10 06:00'
+}
 
-response= HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/INTEGRATION_API/Trigger/post_trigger.rb
+++ b/INTEGRATION_API/Trigger/post_trigger.rb
@@ -1,24 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_key='CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_KEY = 'CHANGE_THIS'
 
-endpoint="https://events.pagerduty.com/generic/2010-04-15/create_event.json"
-token_string="Token token=#{api_token}"
+ENDPOINT = 'https://events.pagerduty.com/generic/2010-04-15/create_event.json'
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       service_key: service_key,
-       incident_key: "srv01/HTTP",
-       event_type: "trigger",
-       description: "FAILURE for production/HTTP on machine srv01.acme.com",
-       client: "Sample Monitoring Service",
-       client_url: "https://monitoring.service.com",
-       details: "ping time: 1500ms, load avg: 0.5" 
-       }
+  service_key: SERVICE_KEY,
+  incident_key: 'srv01/HTTP',
+  event_type: 'trigger',
+  description: 'FAILURE for production/HTTP on machine srv01.acme.com',
+  client: 'Sample Monitoring Service',
+  client_url: 'https://monitoring.service.com',
+  details: 'ping time: 1500ms, load avg: 0.5'
+}
 
-response= HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Alerts/get_alerts.rb
+++ b/REST_API/Alerts/get_alerts.rb
@@ -1,14 +1,23 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-since_date="2014-04-01T01:00Z"
-until_date="2014-04-05T01:00Z"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SINCE_DATE = '2014-04-01T01:00Z'
+UNTIL_DATE = '2014-04-05T01:00Z'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/alerts/"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/alerts/" \
+           "?since=#{SINCE_DATE}&until=#{UNTIL_DATE}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+text = response.body
 puts text

--- a/REST_API/EscalationPolicies/EscalationRules/delete_escalation_rule_id.rb
+++ b/REST_API/EscalationPolicies/EscalationRules/delete_escalation_rule_id.rb
@@ -1,13 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-escalation_id='PITG119'
-rules_id="PDBEMQN"
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{escalation_id}/escalation_rules/#{rules_id}"
-token_string="Token token=#{api_token}"
+subdomain = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_ID = 'PITG119'
+RULES_ID = 'PDBEMQN'
 
-response = HTTParty.delete(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_ID}/escalation_rules/#{RULES_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/EscalationRules/get_escalation_rules.rb
+++ b/REST_API/EscalationPolicies/EscalationRules/get_escalation_rules.rb
@@ -1,11 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-escalation_id='PITG119'
-api_token='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{escalation_id}/escalation_rules"
-token_string="Token token=#{api_token}"
+SUBDOMAIN = 'CHANGE_THIS'
+ESCALATION_ID = 'PITG119'
+API_TOKEN = 'CHANGE_THIS'
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_ID}/escalation_rules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/EscalationRules/get_escalation_rules_id.rb
+++ b/REST_API/EscalationPolicies/EscalationRules/get_escalation_rules_id.rb
@@ -1,12 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-escalation_id='PITG119'
-rules_id="PDBEMQN"
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{escalation_id}/escalation_rules/#{rules_id}"
-token_string="Token token=#{api_token}"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_ID = 'PITG119'
+RULES_ID = 'PDBEMQN'
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_ID}/escalation_rules/#{RULES_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/EscalationRules/post_escalation_rules.rb
+++ b/REST_API/EscalationPolicies/EscalationRules/post_escalation_rules.rb
@@ -1,37 +1,46 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-escalation_id='CHANGE_THIS'
-api_token='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{escalation_id}/escalation_rules"
-token_string="Token token=#{api_token}"
- 
-data= {    
+SUBDOMAIN = 'CHANGE_THIS'
+ESCALATION_ID = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_ID}/escalation_rules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+data = {
   escalation_rule: {
-    id: "PNTPYK0",
+    id: 'PNTPYK0',
     escalation_delay_in_minutes: 10,
     rule_object: {
-      id: "PPSFHH7",
-      name: "Bob Smith",
-      type: "user",
-      email: "bob@acme.com",
-      time_zone: "Eastern Time (US & Canada)",
-      color: "red"
+      id: 'PPSFHH7',
+      name: 'Bob Smith',
+      type: 'user',
+      email: 'bob@acme.com',
+      time_zone: 'Eastern Time (US & Canada)',
+      color: 'red'
     },
     targets: [
       {
-        id: "PPSFHH7",
-        name: "Bob Smith",
-        type: "user",
-        email: "bob@acme.com",
-        time_zone: "Eastern Time (US & Canada)",
-        color: "red"
+        id: 'PPSFHH7',
+        name: 'Bob Smith',
+        type: 'user',
+        email: 'bob@acme.com',
+        time_zone: 'Eastern Time (US & Canada)',
+        color: 'red'
       }
     ]
   }
 }
 
-response = HTTParty.post(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
 puts response.body

--- a/REST_API/EscalationPolicies/EscalationRules/put_escalation_rules.rb
+++ b/REST_API/EscalationPolicies/EscalationRules/put_escalation_rules.rb
@@ -1,34 +1,42 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
- 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-escalation_id='P1UHZGM'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{escalation_id}/escalation_rules"
-token_string="Token token=#{api_token}"
+
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_ID = 'P1UHZGM'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_ID}/escalation_rules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       escalation_rules:[
-       { 
-       id:"PVQ1NPV",
-       escalation_delay_in_minutes:10,
-       rule_object:
-         {
-         id:"P1CYCHE",
-         name:"Ops Weekly",
-         type:"schedule"
-         },
-         targets:[
-           {  
-           id:"P1CYCHE",
-           name:"Ops Weekly",
-           type:"schedule"
-           }
-         ]
-       }
-       ]
-     }
- 
-response = HTTParty.put(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+  escalation_rules: [
+    {
+      id: 'PVQ1NPV',
+      escalation_delay_in_minutes: 10,
+      rule_object: {
+        id: 'P1CYCHE',
+        name: 'Ops Weekly',
+        type: 'schedule'
+      },
+      targets: [
+        {
+          id: 'P1CYCHE',
+          name: 'Ops Weekly',
+          type: 'schedule'
+        }
+     ]
+    }
+  ]
+}
+
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 puts response.body

--- a/REST_API/EscalationPolicies/OnCall/get_on_call.rb
+++ b/REST_API/EscalationPolicies/OnCall/get_on_call.rb
@@ -1,11 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+subdomain = 'CHANGE_THIS'
+api_token = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/on_call/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/escalation_policies" \
+           "/on_call/"
+TOKEN_STRING = "Token token=#{api_token}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/delete_escalation_policies_id.rb
+++ b/REST_API/EscalationPolicies/delete_escalation_policies_id.rb
@@ -1,12 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*
+
 require 'httparty'
- 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-id='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{id}"
-token_string="Token token=#{api_token}"
- 
-response = HTTParty.delete(endpoint,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_POLICY_ID = 'CHANGE_THIS'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_POLICY_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/get_escalation_policies.rb
+++ b/REST_API/EscalationPolicies/get_escalation_policies.rb
@@ -1,11 +1,18 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-schedule_id='PHKTVZ4'
-api_token='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/"
-token_string="Token token=#{api_token}"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/get_escalation_policies_id.rb
+++ b/REST_API/EscalationPolicies/get_escalation_policies_id.rb
@@ -1,11 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
- 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-id="P77DTAB"
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{id}"
-token_string="Token token=#{api_token}"
- 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_POLICY_ID = 'P77DTAB'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_POLICY_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/EscalationPolicies/post_escalation_policies.rb
+++ b/REST_API/EscalationPolicies/post_escalation_policies.rb
@@ -1,27 +1,36 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-schedule_id='CHANGE_THIS'
-api_token='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies"
-token_string="Token token=#{api_token}"
- 
-data= {    
-      name: "Alphabet Policy", 
-      escalation_rules:  [
-        { 
-          escalation_delay_in_minutes: 20, 
-          targets: [
-            { 
-              type: "user", 
-              id: "PPSFHH7" 
-            } 
-          ]
-        } 
-      ],
-      num_loops: 4
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+data = {
+  name: 'Alphabet Policy',
+  escalation_rules: [
+    {
+      escalation_delay_in_minutes: 20,
+      targets: [
+        {
+          type: 'user',
+          id: 'PPSFHH7'
+        }
+      ]
     }
-response = HTTParty.post(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+  ],
+  num_loops: 4
+}
+
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
 puts response.body

--- a/REST_API/EscalationPolicies/put_escalation_policies_id.rb
+++ b/REST_API/EscalationPolicies/put_escalation_policies_id.rb
@@ -1,16 +1,24 @@
-require 'httparty'
- 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-id='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/escalation_policies/#{id}"
-token_string="Token token=#{api_token}"
- 
-data= {    
-      name: "New name" 
-      }
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
 
-response = HTTParty.put(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+require 'httparty'
+
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ESCALATION_POLICY_ID = 'CHANGE_THIS'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/escalation_policies/" \
+           "#{ESCALATION_POLICY_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+data = { name: 'New name' }
+
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
 puts response.body

--- a/REST_API/Incidents/Notes/get_notes.rb
+++ b/REST_API/Incidents/Notes/get_notes.rb
@@ -1,5 +1,7 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
-require 'json'
 
 subdomain='CHANGE_THIS'
 api_token='CHANGE_THIS'

--- a/REST_API/Incidents/Notes/post_notes.rb
+++ b/REST_API/Incidents/Notes/post_notes.rb
@@ -1,22 +1,27 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
-require 'json'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='PWTXP2C'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'PWTXP2C'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}/notes/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/" \
+           "#{INCIDENT_ID}/notes/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       requester_id:"P4RKUT9",
-       note:
-         {
-         content:"New Note"
-         }
-       }
-response = HTTParty.post(endpoint, 
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+  requester_id: 'P4RKUT9',
+  note: { content: 'New Note' }
+}
+
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/get_incidents.rb
+++ b/REST_API/Incidents/get_incidents.rb
@@ -1,11 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/get_incidents_count.rb
+++ b/REST_API/Incidents/get_incidents_count.rb
@@ -1,15 +1,23 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-since_date="2014-04-01T01:00Z"
-until_date="2014-04-05T01:00Z"
-status="resolved"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SINCE_DATE = '2014-04-01T01:00Z'
+UNTIL_DATE = '2014-04-05T01:00Z'
+STATUS = 'resolved'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/count"
-endpoint << "?since=#{since_date}&until=#{until_date}&status=#{status}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/count" \
+           "?since=#{SINCE_DATE}&until=#{UNTIL_DATE}&status=#{STATUS}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/get_incidents_id.rb
+++ b/REST_API/Incidents/get_incidents_id.rb
@@ -1,12 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='PP71KD4'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'PP71KD4'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/#{INCIDENT_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/put_incidents.rb
+++ b/REST_API/Incidents/put_incidents.rb
@@ -1,26 +1,28 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-escalation_id='PITG119'
-rules_id="PDBEMQN"
-api_token='CHANGE_THIS'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents"
-token_string="Token token=#{api_token}"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-data= {
-       requester_id: "P3Y4319",
-       incidents: [
-         {
-         id: "PP71KD4",
-         status: "resolved"
-         }
-       ]
-       }
+data = {
+  requester_id: 'P3Y4319',
+  incidents: [
+    {
+      id: 'PP71KD4', status: 'resolved'
+    }
+  ]
+}
 
-         
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Incidents/put_incidents_ack.rb
+++ b/REST_API/Incidents/put_incidents_ack.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='PCNXB28'
-user_id='P3Y4319'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'PCNXB28'
+USER_ID = 'P3Y4319'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}/acknowledge"
-endpoint << "?requester_id=#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/" \
+           "#{INCIDENT_ID}/acknowledge?requester_id=#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.put(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/put_incidents_reassign.rb
+++ b/REST_API/Incidents/put_incidents_reassign.rb
@@ -1,16 +1,24 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='PWTXP2C'
-user_id='P3Y4319'
-assign_to_user='P4RKUT9'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'PWTXP2C'
+USER_ID = 'P3Y4319'
+ASSIGN_TO_USER = 'P4RKUT9'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}/reassign"
-endpoint << "?requester_id=#{user_id}"
-endpoint << "&assigned_to_user=#{assign_to_user}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/" \
+           "#{INCIDENT_ID}/reassign?requester_id=#{USER_ID}" \
+           "&assigned_to_user=#{ASSIGN_TO_USER}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.put(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Incidents/put_incidents_resolve.rb
+++ b/REST_API/Incidents/put_incidents_resolve.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='P0W25BQ'
-user_id='P3Y4319'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'P0W25BQ'
+USER_ID = 'P3Y4319'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}/resolve"
-endpoint << "?requester_id=#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/" \
+           "#{INCIDENT_ID}/resolve?requester_id=#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.put(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/LogEntries/get_incident_log_entries.rb
+++ b/REST_API/LogEntries/get_incident_log_entries.rb
@@ -1,12 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-incident_id='PWTXP2C'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+INCIDENT_ID = 'PWTXP2C'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/incidents/#{incident_id}/log_entries/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/incidents/" \
+           "#{INCIDENT_ID}/log_entries/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/LogEntries/get_log_entries.rb
+++ b/REST_API/LogEntries/get_log_entries.rb
@@ -1,11 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/log_entries/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/log_entries/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/LogEntries/get_log_entries_id.rb
+++ b/REST_API/LogEntries/get_log_entries_id.rb
@@ -1,12 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-log_id='P4M9NI8'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+LOG_ID = 'P4M9NI8'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/log_entries/#{log_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/log_entries/#{LOG_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/LogEntries/get_user_log_entries.rb
+++ b/REST_API/LogEntries/get_user_log_entries.rb
@@ -1,12 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P4RKUT9'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P4RKUT9'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/log_entries/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/" \
+           "#{USER_ID}/log_entries/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/MaintenanceWindows/delete_maintenance.rb
+++ b/REST_API/MaintenanceWindows/delete_maintenance.rb
@@ -1,13 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-window_id='PL52PNQ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+WINDOW_ID = 'PL52PNQ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/maintenance_windows/#{window_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/maintenance_windows/" \
+           "#{WINDOW_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.delete(endpoint, 
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/MaintenanceWindows/get_maintenance.rb
+++ b/REST_API/MaintenanceWindows/get_maintenance.rb
@@ -1,12 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
-require 'json'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/maintenance_windows/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/maintenance_windows/"
+TOKEN_STRING = "Token token=#{API_KEY}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/MaintenanceWindows/get_maintenance_id.rb
+++ b/REST_API/MaintenanceWindows/get_maintenance_id.rb
@@ -1,13 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 require 'json'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-maintenance_window_id='P1DQUDR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+MAINTENANCE_WINDOW_ID = 'P1DQUDR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/maintenance_windows/#{maintenance_window_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/maintenance_windows/" \
+           "#{MAINTENANCE_WINDOW_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/MaintenanceWindows/post_maintenance.rb
+++ b/REST_API/MaintenanceWindows/post_maintenance.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
 subdomain='CHANGE_THIS'

--- a/REST_API/MaintenanceWindows/put_maintenance.rb
+++ b/REST_API/MaintenanceWindows/put_maintenance.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
 subdomain='CHANGE_THIS'

--- a/REST_API/Reports/get_reports_alerts_per_time.rb
+++ b/REST_API/Reports/get_reports_alerts_per_time.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-since_date="2014-04-01T01:00Z"
-until_date="2014-04-05T01:00Z"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SINCE_DATE = '2014-04-01T01:00Z'
+UNTIL_DATE = '2014-04-05T01:00Z'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/reports/alerts_per_time/"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/reports/" \
+           "alerts_per_time/?since=#{SINCE_DATE}&until=#{UNTIL_DATE}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Reports/get_reports_incidents_per_time.rb
+++ b/REST_API/Reports/get_reports_incidents_per_time.rb
@@ -1,16 +1,24 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-since_date="2014-04-01T01:00Z"
-until_date="2014-04-05T01:00Z"
-timeframe="daily"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SINCE_DATE = '2014-04-01T01:00Z'
+UNTIL_DATE = '2014-04-05T01:00Z'
+TIMEFRAME = 'daily'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/reports/incidents_per_time/"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-endpoint << "&rollup=#{timeframe}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/reports/" \
+           "incidents_per_time/?since=#{SINCE_DATE}&until=#{UNTIL_DATE}" \
+           "&rollup=#{TIMEFRAME}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/Overrides/delete_schedule_schedule_id_overrides.rb
+++ b/REST_API/Schedules/Overrides/delete_schedule_schedule_id_overrides.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PK6D3G2'
-override_id='PYVKJP1'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PK6D3G2'
+OVERRIDE_ID = 'PYVKJP1'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}/overrides/#{override_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/" \
+           "#{SCHEDULE_ID}/overrides/#{OVERRIDE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.delete(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/Overrides/get_schedule_schedule_id_overrides.rb
+++ b/REST_API/Schedules/Overrides/get_schedule_schedule_id_overrides.rb
@@ -1,16 +1,23 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PK6D3G2'
-since_date="2014-07-02T01:00Z"
-until_date="2014-07-05T01:00Z"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PK6D3G2'
+SINCE_DATE = '2014-07-02T01:00Z'
+UNTIL_DATE = '2014-07-05T01:00Z'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}/overrides"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/" \
+           "#{SCHEDULE_ID}/overrides?since=#{SINCE_DATE}&until=#{UNTIL_DATE}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/Overrides/post_schedule_schedule_id_overrides.rb
+++ b/REST_API/Schedules/Overrides/post_schedule_schedule_id_overrides.rb
@@ -1,25 +1,32 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PK6D3G2'
-since_date="2014-07-02T01:00Z"
-until_date="2014-07-05T01:00Z"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PK6D3G2'
+SINCE_DATE = '2014-07-02T01:00Z'
+UNTIL_DATE = '2014-07-05T01:00Z'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}/overrides"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/" \
+           "#{SCHEDULE_ID}/overrides?since=#{SINCE_DATE}&until=#{UNTIL_DATE}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-         override: {
-           user_id: "P8MMFBJ", 
-             start: "2014-07-01",
-             end: "2014-07-09",
-         }
-       }
+  override: {
+    user_id: 'P8MMFBJ',
+    start: '2014-07-01',
+    end: '2014-07-09'
+  }
+}
 
-response = HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/delete_schedules.rb
+++ b/REST_API/Schedules/delete_schedules.rb
@@ -1,11 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PINDC8M'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
-token_string="Token token=#{api_token}"
- 
-response = HTTParty.delete(endpoint,  
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PINDC8M'
+
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/#{SCHEDULE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
 puts response.body

--- a/REST_API/Schedules/get_schedule_id_entries.rb
+++ b/REST_API/Schedules/get_schedule_id_entries.rb
@@ -1,17 +1,25 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PU558LC'
-user_id='PMUQ3OT'
-since_date="2014-05-02T01:00Z"
-until_date="2014-05-05T01:00Z"
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PU558LC'
+USER_ID = 'PMUQ3OT'
+SINCE_DATE = '2014-05-02T01:00Z'
+UNTIL_DATE = '2014-05-05T01:00Z'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}/entries"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-endpoint << "&user_id=#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/" \
+           "#{SCHEDULE_ID}/entries?since=#{SINCE_DATE}&until=" \
+           "#{UNTIL_DATE}&user_id=#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/get_schedules.rb
+++ b/REST_API/Schedules/get_schedules.rb
@@ -1,11 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/get_schedules_id.rb
+++ b/REST_API/Schedules/get_schedules_id.rb
@@ -1,12 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PUV0FUY'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PUV0FUY'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/#{SCHEDULE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/get_schedules_id_users.rb
+++ b/REST_API/Schedules/get_schedules_id_users.rb
@@ -1,15 +1,23 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-since_date="2014-06-01T01:00Z"
-until_date="2014-06-05T01:00Z"
-schedule_id='PZM13ZV'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SINCE_DATE = '2014-06-01T01:00Z'
+UNTIL_DATE = '2014-06-05T01:00Z'
+SCHEDULE_ID = 'PZM13ZV'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}/users/"
-endpoint << "?since=#{since_date}&until=#{until_date}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules/" \
+           "#{SCHEDULE_ID}/users/?since=#{SINCE_DATE}&until=#{UNTIL_DATE}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Schedules/post_schedules.rb
+++ b/REST_API/Schedules/post_schedules.rb
@@ -1,88 +1,97 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='pdt-julian'
-api_token='uxTycxhPbwYcyYMX93kR'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules"
-token_string="Token token=#{api_token}"
- 
-data= {    
-     since: "2014-08-05T00:00:00",
-     overflow: 1,
-     until: "2014-08-19T00:00:00",
-     schedule: {
-       schedule_layers: [
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/schedules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
+
+data = {
+  since: '2014-08-05T00:00:00',
+  overflow: 1,
+  until: '2014-08-19T00:00:00',
+  schedule: {
+    schedule_layers: [
+      {
+        start: '2014-08-05T00:00:00',
+        users: [
           {
-            start: "2014-08-05T00:00:00",
-            users: [
-              {
-                user: {
-                  id: "PDKNMCR"
-                },
-                member_order: 1
-              },
-              {
-                user: {
-                  id: "PY050V0"
-                },
-                member_order: 2
-              }
-            ],
-            restriction_type: "Daily",
-            rotation_virtual_start: "2014-08-05T00:00:00",
-            priority: 0,
-            rotation_turn_length_seconds: 604800,
-            end: "2014-08-19T00:00:00",
-            restrictions: [
-                { duration_seconds: 43200,
-                start_time_of_day: "00:00:00" }
-            ],
-            id: "null",
-            name: "Schedule Layer 1"
+            user: {
+              id: 'PDKNMCR'
+            },
+            member_order: 1
           },
           {
-            start: "2014-08-05T00:00:00",
-            users: [
-              {
-                user: {
-                  id: "PS7KGP7"
-                },
-                member_order: 1
-              },
-              {
-                user: {
-                  id: "PSUHY8X"
-                },
-                member_order: 2
-              },
-              {
-                user: {
-                  id: "P8MWLT4"
-                },
-                member_order: 3
-              }
-            ],
-            restriction_type: "Daily",
-            rotation_virtual_start: "2014-08-05T00:00:00",
-            rotation_turn_length_seconds: 86400,
-            priority: 1,
-            restrictions: [
-              {
-                duration_seconds: 43200,
-                start_time_of_day: "00:00:00"
-              }
-            ],
-            end: "2014-08-19T00:00:00",
-            id: "null",
-            name: "Schedule Layer 2"
+            user: {
+              id: 'PY050V0'
+            },
+            member_order: 2
           }
         ],
-        time_zone: "Eastern Time (US & Canada)",
-        id: "null",
-        name: "API-Generated Primary On-Call Schedule"
+        restriction_type: 'Daily',
+        rotation_virtual_start: '2014-08-05T00:00:00',
+        priority: 0,
+        rotation_turn_length_seconds: 604_800,
+        end: '2014-08-19T00:00:00',
+        restrictions: [
+          {
+            duration_seconds: 43_200,
+            start_time_of_day: '00:00:00'
+          }
+        ],
+        id: 'null',
+        name: 'Schedule Layer 1'
+      },
+      {
+        start: '2014-08-05T00:00:00',
+        users: [
+          {
+            user: {
+              id: 'PS7KGP7'
+            },
+            member_order: 1
+          },
+          {
+            user: {
+              id: 'PSUHY8X'
+            },
+            member_order: 2
+          },
+          {
+            user: {
+              id: 'P8MWLT4'
+            },
+            member_order: 3
+          }
+        ],
+        restriction_type: 'Daily',
+        rotation_virtual_start: '2014-08-05T00:00:00',
+        rotation_turn_length_seconds: 86_400,
+        priority: 1,
+        restrictions: [
+          {
+            duration_seconds: 43_200,
+            start_time_of_day: '00:00:00'
+          }
+        ],
+        end: '2014-08-19T00:00:00',
+        id: 'null',
+        name: 'Schedule Layer 2'
       }
-    }
+    ],
+    time_zone: 'Eastern Time (US & Canada)',
+    id: 'null',
+    name: 'API-Generated Primary On-Call Schedule'
+  }
+}
 
-response = HTTParty.post(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+response = HTTParty.post(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 puts response.body

--- a/REST_API/Schedules/put_schedules.rb
+++ b/REST_API/Schedules/put_schedules.rb
@@ -1,16 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-schedule_id='PUV0FUY'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
-token_string="Token token=#{api_token}"
- 
-data= {    
-        name: "3day"
-      }
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'PUV0FUY'
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
+TOKEN_STRING = "Token token=#{api_token}"
 
-response = HTTParty.put(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+data = { name: '3day' }
+
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 puts response.body

--- a/REST_API/Schedules/put_schedules_id.rb
+++ b/REST_API/Schedules/put_schedules_id.rb
@@ -1,89 +1,99 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='pdt-julian'
-api_token='uxTycxhPbwYcyYMX93kR'
-schedule_id='POP0QMD'
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
-token_string="Token token=#{api_token}"
- 
-data= {    
-     since: "2014-08-05T00:00:00",
-     overflow: 1,
-     until: "2014-08-19T00:00:00",
-     schedule: {
-       schedule_layers: [
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SCHEDULE_ID = 'POP0QMD'
+
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/schedules/#{schedule_id}"
+TOKEN_STRING = "Token token=#{api_token}"
+
+data = {
+  since: '2014-08-05T00:00:00',
+  overflow: 1,
+  until: '2014-08-19T00:00:00',
+  schedule: {
+    schedule_layers: [
+      {
+        start: '2014-08-05T00:00:00',
+        users: [
           {
-            start: "2014-08-05T00:00:00",
-            users: [
-              {
-                user: {
-                  id: "PDKNMCR"
-                },
-                member_order: 1
-              },
-              {
-                user: {
-                  id: "PY050V0"
-                },
-                member_order: 2
-              }
-            ],
-            restriction_type: "Daily",
-            rotation_virtual_start: "2014-08-05T00:00:00",
-            priority: 0,
-            rotation_turn_length_seconds: 604800,
-            end: "2014-08-19T00:00:00",
-            restrictions: [
-                { duration_seconds: 43200,
-                start_time_of_day: "00:00:00" }
-            ],
-            id: "PP3RRD7",
-            name: "Schedule Layer 1"
+            user: {
+              id: 'PDKNMCR'
+            },
+            member_order: 1
           },
           {
-            start: "2014-08-05T00:00:00",
-            users: [
-              {
-                user: {
-                  id: "PS7KGP7"
-                },
-                member_order: 1
-              },
-              {
-                user: {
-                  id: "PSUHY8X"
-                },
-                member_order: 2
-              },
-              {
-                user: {
-                  id: "P8MWLT4"
-                },
-                member_order: 3
-              }
-            ],
-            restriction_type: "Daily",
-            rotation_virtual_start: "2014-08-05T00:00:00",
-            rotation_turn_length_seconds: 86400,
-            priority: 1,
-            restrictions: [
-              {
-                duration_seconds: 2200,
-                start_time_of_day: "00:00:00"
-              }
-            ],
-            end: "2014-08-19T00:00:00",
-            id: "P18UPZ4",
-            name: "Schedule Layer 2"
+            user: {
+              id: 'PY050V0'
+            },
+            member_order: 2
           }
         ],
-        time_zone: "Eastern Time (US & Canada)",
-        id: "null",
-        name: "API-Generated Primary On-Call Schedule"
+        restriction_type: 'Daily',
+        rotation_virtual_start: '2014-08-05T00:00:00',
+        priority: 0,
+        rotation_turn_length_seconds: 604_800,
+        end: '2014-08-19T00:00:00',
+        restrictions: [
+          {
+            duration_seconds: 43_200,
+            start_time_of_day: '00:00:00'
+          }
+        ],
+        id: 'PP3RRD7',
+        name: 'Schedule Layer 1'
+      },
+      {
+        start: '2014-08-05T00:00:00',
+        users: [
+          {
+            user: {
+              id: 'PS7KGP7'
+            },
+            member_order: 1
+          },
+          {
+            user: {
+              id: 'PSUHY8X'
+            },
+            member_order: 2
+          },
+          {
+            user: {
+              id: 'P8MWLT4'
+            },
+            member_order: 3
+          }
+        ],
+        restriction_type: 'Daily',
+        rotation_virtual_start: '2014-08-05T00:00:00',
+        rotation_turn_length_seconds: 86_400,
+        priority: 1,
+        restrictions: [
+          {
+            duration_seconds: 2200,
+            start_time_of_day: '00:00:00'
+          }
+        ],
+        end: '2014-08-19T00:00:00',
+        id: 'P18UPZ4',
+        name: 'Schedule Layer 2'
       }
-    }
+    ],
+    time_zone: 'Eastern Time (US & Canada)',
+    id: 'null',
+    name: 'API-Generated Primary On-Call Schedule'
+  }
+}
 
-response = HTTParty.put(endpoint,  
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 puts response.body

--- a/REST_API/Services/EmailFilters/delete_services_id_email_filters.rb
+++ b/REST_API/Services/EmailFilters/delete_services_id_email_filters.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PPVUPKM'
-email_filter_id='P753H50'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PPVUPKM'
+EMAIL_FILTER_ID = 'P753H50'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/email_filters/#{email_filter_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/#{SERVICE_ID}" \
+           "/email_filters/#{EMAIL_FILTER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response= HTTParty.delete(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Services/EmailFilters/post_services_id_email_filters.rb
+++ b/REST_API/Services/EmailFilters/post_services_id_email_filters.rb
@@ -1,20 +1,29 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PPVUPKM'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PPVUPKM'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/email_filters"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/" \
+           "#{SERVICE_ID}/email_filters"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       email_filter:
-       {  body_mode:"no-match",
-          body_regex:"sev 3"}
-       }
+  email_filter: {
+    body_mode: 'no-match',
+    body_regex: 'sev 3'
+  }
+}
 
-response= HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Services/EmailFilters/put_services_id_email_filters.rb
+++ b/REST_API/Services/EmailFilters/put_services_id_email_filters.rb
@@ -1,21 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PPVUPKM'
-email_filter_id='P753H50'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PPVUPKM'
+EMAIL_FILTER_ID = 'P753H50'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/email_filters/#{email_filter_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}" \
+           "/email_filters/#{email_filter_id}"
+TOKEN_STRING = "Token token=#{api_token}"
 
 data = {
-       email_filter:
-       {  from_email_mode:"match",
-          from_email_regex:"[rR]yan"}
-       }
+  email_filter: {
+    from_email_mode: 'match',
+    from_email_regex: '[rR]yan'
+  }
+}
 
-response= HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Services/delete_services.rb
+++ b/REST_API/Services/delete_services.rb
@@ -1,14 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='P1E178O'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'P1E178O'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/#{SERVICE_ID}"
+TOKEN_STRING = "Token token=#{API_KEY}"
 
-token_string="Token token=#{api_token}"
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.delete(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Services/get_services.rb
+++ b/REST_API/Services/get_services.rb
@@ -1,16 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/"
-endpoint << "?include[]=escalation_policy"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/" \
+           "?include[]=escalation_policy"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-token_string="Token token=#{api_token}"
-
-
-
-response = HTTParty.get(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+puts response.body

--- a/REST_API/Services/get_services_id.rb
+++ b/REST_API/Services/get_services_id.rb
@@ -1,14 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PBPBH11'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PBPBH11'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/#{SERVICE_SID}"
+TOKEN_STRING = "Token token=#{api_token}"
 
-token_string="Token token=#{api_token}"
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.get(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Services/post_services.rb
+++ b/REST_API/Services/post_services.rb
@@ -1,25 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-token_string="Token token=#{api_token}"
+data = {
+  service: {
+    name: 'default-email',
+    description: 'default email service',
+    escalation_policy_id: 'PIJ90N7',
+    type: 'generic_email',
+    service_key: 'default-email'
+  }
+}
 
-data =
-      {    
-      service: {
-        name: "default-email",
-        description: "default email service",
-        escalation_policy_id: "PIJ90N7",
-        type: "generic_email",
-        service_key: "default-email"
-      }
-      }
+response = HTTParty.post(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Services/post_services_id_regenerate_key.rb
+++ b/REST_API/Services/post_services_id_regenerate_key.rb
@@ -1,13 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PJN9IRR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PJN9IRR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/regenerate_key"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/services/" \
+           "#{service_id}/regenerate_key"
+TOKEN_STRING = "Token token=#{api_token}"
 
-response= HTTParty.post(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Services/put_services.rb
+++ b/REST_API/Services/put_services.rb
@@ -1,24 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PPYL9PR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PPYL9PR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}"
 
-token_string="Token token=#{api_token}"
+TOKEN_STRING = "Token token=#{api_token}"
 
-data =
-      {    
-      service: {
-        name: "My New Name",
-        description: "Brand New Description",
-        escalation_policy_id: "PBL9SYQ"
-      }
-      }
+data = {
+  service: {
+    name: 'My New Name',
+    description: 'Brand New Description',
+    escalation_policy_id: 'PBL9SYQ'
+  }
+}
 
-response = HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Services/put_services_id_disable.rb
+++ b/REST_API/Services/put_services_id_disable.rb
@@ -1,20 +1,24 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PSWE3MC'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PSWE3MC'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/disable"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/services/" \
+           "#{service_id}/disable"
+TOKEN_STRING = "Token token=#{api_token}"
 
-token_string="Token token=#{api_token}"
+data = { requester_id: 'PMUQ3OT' }
 
-data =
-      {    
-      requester_id: "PMUQ3OT"
-      }
+response = HTTParty.put(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Services/put_services_id_enable.rb
+++ b/REST_API/Services/put_services_id_enable.rb
@@ -1,20 +1,24 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-service_id='PSWE3MC'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+SERVICE_ID = 'PSWE3MC'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/services/#{service_id}/enable"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/services/" \
+           "#{service_id}/enable"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-token_string="Token token=#{api_token}"
+data = { requester_id: 'PMUQ3OT' }
 
-data =
-      {    
-      requester_id: "PMUQ3OT"
-      }
+response = HTTParty.put(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
 
-response = HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+puts response.body

--- a/REST_API/Users/ContactMethods/delete_users_user_id_contact_methods.rb
+++ b/REST_API/Users/ContactMethods/delete_users_user_id_contact_methods.rb
@@ -1,16 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P7BOI8S'
-contact_method_id='PAN6SYJ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P7BOI8S'
+CONTACT_METHOD_ID = 'PAN6SYJ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/contact_methods/#{contact_method_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/contact_methods/#{CONTACT_METHOD_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-data = {contact_method:{type:"phone",address:"5558888888",label:"Island Lair",country_code:"1"}}
-       
-response = HTTParty.delete(endpoint, 
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/ContactMethods/get_users_user_id_contact_methods.rb
+++ b/REST_API/Users/ContactMethods/get_users_user_id_contact_methods.rb
@@ -1,12 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P7BOI8S'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P7BOI8S'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/contact_methods"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/" \
+           "#{USER_ID}/contact_methods"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/ContactMethods/get_users_user_id_contact_methods_id.rb
+++ b/REST_API/Users/ContactMethods/get_users_user_id_contact_methods_id.rb
@@ -1,13 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P7BOI8S'
-contact_method_id='P8Y66QQ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P7BOI8S'
+CONTACT_METHOD_ID = 'P8Y66QQ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/contact_methods/#{contact_method_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/contact_methods/#{CONTACT_METHOD_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/ContactMethods/post_users_user_id_contact_methods.rb
+++ b/REST_API/Users/ContactMethods/post_users_user_id_contact_methods.rb
@@ -1,16 +1,31 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P7BOI8S'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P7BOI8S'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/contact_methods"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/" \
+           "#{USER_ID}/contact_methods"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-data = {contact_method:{type:"phone",address:"5551112222",label:"Island Lair",country_code:"1"}}
-       
-response = HTTParty.post(endpoint, 
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+data = {
+  contact_method: {
+    type: 'phone',
+    address: '5558888888',
+    label: 'Island Lair',
+    country_code: 1
+  }
+}
+
+response = HTTParty.post(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/ContactMethods/put_users_user_id_contact_methods.rb
+++ b/REST_API/Users/ContactMethods/put_users_user_id_contact_methods.rb
@@ -1,17 +1,32 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P7BOI8S'
-contact_method_id='PAN6SYJ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P7BOI8S'
+CONTACT_METHOD_ID = 'PAN6SYJ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/contact_methods/#{contact_method_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/contact_methods/#{CONTACT_METHOD_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-data = {contact_method:{type:"phone",address:"5558888888",label:"Island Lair",country_code:"1"}}
-       
-response = HTTParty.put(endpoint, 
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+data = {
+  contact_method: {
+    type: 'phone',
+    address: '5558888888',
+    label: 'Island Lair',
+    country_code: 1
+  }
+}
+
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/NotificationRules/delete_users_user_id_notification_rules_id.rb
+++ b/REST_API/Users/NotificationRules/delete_users_user_id_notification_rules_id.rb
@@ -1,14 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PPROI4P'
-notification_rule_id='PWKA4EQ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PPROI4P'
+NOTIFICATION_RULE_ID = 'PWKA4EQ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/notification_rules/#{notification_rule_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/notification_rules/#{NOTIFICATION_RULE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.delete(endpoint, 
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/NotificationRules/get_users_user_id_notification_rules.rb
+++ b/REST_API/Users/NotificationRules/get_users_user_id_notification_rules.rb
@@ -1,12 +1,21 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PPROI4P'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PPROI4P'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/notification_rules"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/notification_rules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/NotificationRules/get_users_user_id_notification_rules_id.rb
+++ b/REST_API/Users/NotificationRules/get_users_user_id_notification_rules_id.rb
@@ -1,13 +1,22 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PPROI4P'
-notification_rule_id='PWKA4EQ'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PPROI4P'
+NOTIFICATION_RULE_ID = 'PWKA4EQ'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/notification_rules/#{notification_rule_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/" \
+           "#{USER_ID}/notification_rules/#{NOTIFICATION_RULE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/NotificationRules/post_users_user_id_notification_rules.rb
+++ b/REST_API/Users/NotificationRules/post_users_user_id_notification_rules.rb
@@ -1,22 +1,30 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PPROI4P'
-notification_rule_id='PNDA501'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PPROI4P'
+NOTIFICATION_RULE_ID = 'PNDA501'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/notification_rules"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/" \
+           "#{USER_ID}/notification_rules"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       notification_rule: {
-         contact_method_id:notification_rule_id,
-         start_delay_in_minutes:4
-         }
-       }
+  notification_rule: {
+    contact_method_id: NOTIFICATION_RULE_ID,
+    start_delay_in_minutes: 4
+  }
+}
 
-response = HTTParty.post(endpoint, 
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/NotificationRules/put_users_user_id_notification_rules.rb
+++ b/REST_API/Users/NotificationRules/put_users_user_id_notification_rules.rb
@@ -1,23 +1,31 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PPROI4P'
-notification_rule_id='PWKA4EQ'
-contact_method_id='PNDA501'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PPROI4P'
+NOTIFICATION_RULE_ID = 'PWKA4EQ'
+CONTACT_METHOD_ID = 'PNDA501'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/notification_rules/#{notification_rule_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}" \
+           "/notification_rules/#{NOTIFICATION_RULE_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       notification_rule: {
-         contact_method_id:contact_method_id,
-         start_delay_in_minutes:5
-         }
-       }
+  notification_rule: {
+    contact_method_id: CONTACT_METHOD_ID,
+    start_delay_in_minutes: 5
+  }
+}
 
-response = HTTParty.put(endpoint, 
-                         :body => data.to_json,
-                         :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/OnCall/get_users_id_on_call.rb
+++ b/REST_API/Users/OnCall/get_users_id_on_call.rb
@@ -1,12 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PDKNMCR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PDKNMCR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}/on_call"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}/on_call"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/delete_users_id.rb
+++ b/REST_API/Users/delete_users_id.rb
@@ -1,13 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P2ML0HR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P2ML0HR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response= HTTParty.delete(endpoint, 
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.delete(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+puts response.body

--- a/REST_API/Users/get_users.rb
+++ b/REST_API/Users/get_users.rb
@@ -1,11 +1,19 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  endpoint,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/get_users_id.rb
+++ b/REST_API/Users/get_users_id.rb
@@ -1,12 +1,20 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='PDKNMCR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'PDKNMCR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
-response = HTTParty.get(endpoint, :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.get(
+  ENDPOINT,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/post_users.rb
+++ b/REST_API/Users/post_users.rb
@@ -1,21 +1,28 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-requester_id='P3Y4319'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+REQUESTER_ID = 'P3Y4319'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{subdomain}.pagerduty.com/api/v1/users"
+TOKEN_STRING = "Token token=#{api_token}"
 
 data = {
-       role: "admin",
-       name: "Bart Simpson",
-       email: "bart@example.com",
-       requester_id: requester_id,
-       }
+  role: 'admin',
+  name: 'Bart Simpson',
+  email: 'bart@example.com',
+  requester_id: REQUESTER_ID
+}
 
-response= HTTParty.post(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.post(
+  endpoint,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body

--- a/REST_API/Users/put_users_id.rb
+++ b/REST_API/Users/put_users_id.rb
@@ -1,22 +1,29 @@
+#!/usr/bin/env ruby
+# -*- coding: UTF-8 -*-
+
 require 'httparty'
 
-subdomain='CHANGE_THIS'
-api_token='CHANGE_THIS'
-user_id='P2ML0HR'
+SUBDOMAIN = 'CHANGE_THIS'
+API_TOKEN = 'CHANGE_THIS'
+USER_ID = 'P2ML0HR'
 
-endpoint="https://#{subdomain}.pagerduty.com/api/v1/users/#{user_id}"
-token_string="Token token=#{api_token}"
+ENDPOINT = "https://#{SUBDOMAIN}.pagerduty.com/api/v1/users/#{USER_ID}"
+TOKEN_STRING = "Token token=#{API_TOKEN}"
 
 data = {
-       user: {
-         role: "admin",
-         name: "Bart Simpson",
-         email: "bart@example.com",
-         }
-       }
+  user: {
+    role: 'admin',
+    name: 'Bart Simpson',
+    email: 'bart@example.com'
+  }
+}
 
-response= HTTParty.put(endpoint, 
-                        :body => data.to_json,
-                        :headers => { "Content-Type" => 'application/json', "Authorization" => token_string})
-text= response.body
-puts text
+response = HTTParty.put(
+  ENDPOINT,
+  body: data.to_json,
+  headers: {
+    'Content-Type' => 'application/json', 'Authorization' => TOKEN_STRING
+  }
+)
+
+puts response.body


### PR DESCRIPTION
This huge patch makes adjustments to all Ruby source files. The code was adjusted to be readable and fit within the common Ruby idioms. The Rubocop linter was used, with default configuration, to report any style errors.

The following style items were addressed:
- Adding spaces around an assignment operator

So when assigning a variable, it should have spaces around the `=` symbol. For hashes, there should be a space between the key and the value: `{ key: 'value' }`
- shebang + encoding

This adds a proper Ruby shebang and encoding comment at the top. The latter is a Rubocop thing, but still good to have.
- Ruby 1.9-style hashes

For 1.9, the hashes had the following syntax: `{ :key => 'value' }`, in Ruby 1.9 you can do: `{ key: 'value' }`
- Proper indenting

This is making sure that each indentation level is a multiple of 2 spaces, with 0 being the minimum. This also makes sure that all indentation is consistent everywhere.
- Trailing whitespace

Remove any whitespace at the end of the line, or just random whitespace in the middle of the file
- Make sure things that are being treated as constant are defined as a constant

Constant definition in Ruby isn't a hard constant, you can overwrite it but Ruby will warn. It's usually best form to define constants as constants. To do so in Ruby, just make your variable name consist of all capital letters:

``` Ruby
CONTSTANT_HERE = :ohai
```
- Use single quotes when there is no String interpolation

If you aren't trying to print the contents of a variable in a string (e.g, `puts "hello #{person_name}"`), you should use single quotes:

`'Hello'` instead of `"Hello"`. However, due to interpolation being needed this won't work: `'Greetings #{name}!'`
- Unused variables

There were quite a few variables that were just hanging around; this could make the examples more confusing to understand. I just removed these to improve readability.

This also removes the lingering API keys and subdomain names.
